### PR TITLE
Change `setup.py` to NOT install `multiprocessing` with Python 3 or 2.6+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 """
 My Tool does one thing, and one thing well.
 """
+import sys
 from setuptools import find_packages, setup
 
 
@@ -28,7 +29,14 @@ def install_deps():
     new_pkgs = []
     links = []
     for resource in default:
-        if 'git+https' in resource:
+        """
+        Do not install multiprocessing for Python 2.6+ or 3+:
+        """
+        py3_26_or_higher = sys.version_info[0]==3 or \
+           (sys.version_info[0]==2 and sys.version_info[0]>5)
+        if py3_26_or_higher and 'multiprocessing' in resource:
+            pass
+        elif 'git+https' in resource:
             pkg = resource.split('#')[-1]
             links.append(resource.strip() + '-9876543210')
             new_pkgs.append(pkg.replace('egg=', '').rstrip())


### PR DESCRIPTION
Hi @jayanthjaiswal,

I tried to install with pip for python 3.7 today and stumbled upon the following error:
```
Collecting git+git://github.com/cdli-gh/atf2conll-convertor.git
  Cloning git://github.com/cdli-gh/atf2conll-convertor.git to c:\users\eli\appdata\local\temp\pip-req-build-pfs0v8ze
DEPRECATION: Dependency Links processing has been deprecated and will be removed in a future release. You can find discussion regarding this at https://github.com/pypa/pip/issues/4187.
Requirement already satisfied: click in c:\python\virtenvs\mtaac\lib\site-packages (from atf2conllconvertor==0.2.10) (6.7)
Collecting pyoracc (from atf2conllconvertor==0.2.10)
  Cloning https://git@github.com/cdli-gh/pyoracc.git (to revision master) to c:\users\eli\appdata\local\temp\pip-install-zlfb68ca\pyoracc
Collecting mako (from pyoracc->atf2conllconvertor==0.2.10)
  Downloading https://files.pythonhosted.org/packages/eb/f3/67579bb486517c0d49547f9697e36582cd19dafb5df9e687ed8e22de57fa/Mako-1.0.7.tar.gz (564kB)
    100% |████████████████████████████████| 573kB 979kB/s
Collecting ply (from pyoracc->atf2conllconvertor==0.2.10)
  Downloading https://files.pythonhosted.org/packages/a3/58/35da89ee790598a0700ea49b2a66594140f44dec458c07e8e3d4979137fc/ply-3.11-py2.py3-none-any.whl (49kB)
    100% |████████████████████████████████| 51kB 1.0MB/s
Collecting multiprocessing (from pyoracc->atf2conllconvertor==0.2.10)
  Downloading https://files.pythonhosted.org/packages/b8/8a/38187040f36cec8f98968502992dca9b00cc5e88553e01884ba29cbe6aac/multiprocessing-2.6.2.1.tar.gz (108kB)
    100% |████████████████████████████████| 112kB 1.6MB/s
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "C:\Users\Eli\AppData\Local\Temp\pip-install-zlfb68ca\multiprocessing\setup.py", line 94
        print 'Macros:'
                      ^
    SyntaxError: Missing parentheses in call to 'print'. Did you mean print('Macros:')?

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in C:\Users\Eli\AppData\Local\Temp\pip-install-zlfb68ca\multiprocessing\
```
Apparently, the program uses the package `multiprocessing`, which is already included in standard Python 2.6+ and 3. Moreover, the package's setup itself is incompatible with Python 3, which causes the error. I changed the setup to ignore the package when Python is 3 / 2.6 or higher. 

	modified:   setup.py