### PR TITLE
Fix: handle @fragment surface to generate unique IDs

### DIFF
--- a/atf2conll_convertor/convertor.py
+++ b/atf2conll_convertor/convertor.py
@@ -107,6 +107,7 @@ class ATFCONLConvertor:
             elif firstword == "column":
                 self.column = 'col' + tokenizedLine[-1]
             elif firstword == "fragment":
+                self.surfaceMode = "f"
                 try:
                     self.column = tokenizedLine[1]
                 except IndexError:

--- a/resources/test_fragment.atf
+++ b/resources/test_fragment.atf
@@ -1,0 +1,8 @@
+&P222243 = CDLI Fragment Test
+#atf: lang sux
+@tablet
+@fragment a
+1. sze-bi gur
+2. mu ba-hul
+@fragment b
+1. a-na dumu-szu2

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,6 +23,33 @@ ATF_BILINGUAL = """\
 2. _sze gur_ ba-an-si
 """
 
+ATF_FRAGMENT_SINGLE = """\
+&P222243 = Test Fragment
+#atf: lang sux
+@tablet
+@fragment a
+1. sze-bi gur
+2. mu ba-hul
+"""
+
+ATF_FRAGMENT_MULTI = """\
+&P222243 = Test Multi Fragment
+#atf: lang sux
+@tablet
+@fragment a
+1. sze-bi gur
+@fragment b
+1. mu ba-hul
+"""
+
+ATF_FRAGMENT_NO_LETTER = """\
+&P222243 = Test No Letter Fragment
+#atf: lang sux
+@tablet
+@fragment
+1. sze-bi gur
+"""
+
 
 def make_convertor(atf_content):
     with tempfile.NamedTemporaryFile(mode='w', suffix='.atf', delete=False, encoding='utf-8') as f:
@@ -74,5 +101,49 @@ def test_special_chars_removed():
         for form in forms:
             for ch in ('#', '[', ']', '<', '>', '!', '?'):
                 assert ch not in form, f'{ch!r} found in output token: {form!r}'
+    finally:
+        os.unlink(fname)
+
+
+def test_fragment_ids_have_surface_prefix():
+    """@fragment surface should produce IDs starting with 'f', not a bare dot."""
+    fname, c = make_convertor(ATF_FRAGMENT_SINGLE)
+    try:
+        c.convert()
+        for token_id, _ in c.tokens:
+            assert not token_id.startswith('.'), (
+                f"ID '{token_id}' starts with dot — fragment surface prefix missing"
+            )
+        assert c.tokens[0][0] == 'f.a.1.1'
+        assert c.tokens[1][0] == 'f.a.1.2'
+        assert c.tokens[2][0] == 'f.a.2.1'
+        assert c.tokens[3][0] == 'f.a.2.2'
+    finally:
+        os.unlink(fname)
+
+
+def test_fragment_ids_are_unique_across_fragments():
+    """Multiple @fragment sections must produce globally unique IDs."""
+    fname, c = make_convertor(ATF_FRAGMENT_MULTI)
+    try:
+        c.convert()
+        id_list = [tok[0] for tok in c.tokens]
+        assert len(id_list) == len(set(id_list)), "Duplicate IDs found in multi-fragment text"
+        assert c.tokens[0][0] == 'f.a.1.1'
+        assert c.tokens[2][0] == 'f.b.1.1'
+    finally:
+        os.unlink(fname)
+
+
+def test_fragment_no_letter_has_surface_prefix():
+    """@fragment with no letter should still produce IDs starting with 'f'."""
+    fname, c = make_convertor(ATF_FRAGMENT_NO_LETTER)
+    try:
+        c.convert()
+        for token_id, _ in c.tokens:
+            assert not token_id.startswith('.'), (
+                f"ID '{token_id}' starts with dot — fragment surface prefix missing"
+            )
+        assert c.tokens[0][0].startswith('f.')
     finally:
         os.unlink(fname)


### PR DESCRIPTION
Fixes #23

## Problem
When an ATF file contains `@fragment` sections, the converter sets
`self.column` to the fragment letter (e.g. "a", "b") but never sets
`self.surfaceMode`. This results in token IDs like `.a.1.1` (leading dot)
instead of `f.a.1.1`, breaking the CoNLL ID format.

For `@fragment` with no letter, both values stay empty, producing IDs
like `.1.1` with no surface identifier at all.

## Fix
Set `self.surfaceMode = "f"` whenever a `@fragment` line is encountered,
consistent with how other surfaces are handled (e.g. `o` for obverse,
`r` for reverse, `t` for top).

## Tests added
- `test_fragment_ids_have_surface_prefix` — verifies IDs start with `f.`
- `test_fragment_ids_are_unique_across_fragments` — verifies multi-fragment uniqueness
- `test_fragment_no_letter_has_surface_prefix` — verifies bare `@fragment` works too